### PR TITLE
Added tracked_storage class to keep track of memory allocated to a boost multi-index.

### DIFF
--- a/include/fc/container/tracked_storage.hpp
+++ b/include/fc/container/tracked_storage.hpp
@@ -1,0 +1,104 @@
+#pragma once
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/global_fun.hpp>
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/filesystem.hpp>
+#include <fc/exception/exception.hpp>
+#include <fc/io/cfile.hpp>
+#include <fc/io/datastream.hpp>
+#include <fc/io/fstream.hpp>
+#include <fc/io/raw.hpp>
+#include <fstream>
+
+namespace eosio::chain_apis {
+   namespace bfs = boost::filesystem;
+
+   /**
+    * @class tracked_storage
+    * @brief tracks the size of storage allocated to its underlying multi_index
+    *
+    * This class wraps a multi_index container and tracks the memory allocated as
+    * the container creates, modifies, and deletes.
+    */
+
+   template <typename ContainerType, typename Value, typename PrimaryTag>
+   class tracked_storage {
+   private:
+      uint64_t _size = 0;
+      ContainerType _index;
+   public:
+      typedef PrimaryTag primary_tag;
+      typedef typename ContainerType::template index<primary_tag>::type primary_index_type;
+
+      tracked_storage() {
+
+      }
+
+      void read(fc::cfile_datastream& ds, uint64_t max_memory) {
+         auto container_size = _index.size();
+         fc::raw::unpack(ds, container_size);
+         for (uint64_t i = 0; i < container_size && size() < max_memory; ++i) {
+            Value v;
+            fc::raw::unpack(ds, v);
+            insert(std::move(v));
+         }
+      }
+
+      void write(fc::cfile& dat_content) const {
+         const auto container_size = _index.size();
+         dat_content.write( reinterpret_cast<const char*>(&container_size), sizeof(container_size) );
+         const primary_index_type& primary_idx = _index.template get<primary_tag>();
+         
+         for (auto itr = primary_idx.cbegin(); itr != primary_idx.cend(); ++itr) {
+            auto data = fc::raw::pack(*itr);
+            dat_content.write(data.data(), data.size());
+         }
+      }
+
+      void insert(Value&& obj) {
+         _index.insert(obj);
+         _size += obj.size();
+      }
+
+      template<typename Key>
+      typename primary_index_type::iterator find(const Key& key) {
+         primary_index_type& primary_idx = _index.template get<primary_tag>();
+         return primary_idx.find(key);
+      }
+
+      template<typename Key>
+      typename primary_index_type::const_iterator find(const Key& key) const {
+         const primary_index_type& primary_idx = _index.template get<primary_tag>();
+         return primary_idx.find(key);
+      }
+
+      template<typename Lam>
+      void modify(typename primary_index_type::iterator itr, Lam&& lam) {
+         const auto orig_size = itr->size();
+         _index.modify( itr, std::move(lam));
+         _size += itr->size() - orig_size;
+      }
+
+      template<typename Key>
+      void erase(const Key& key) {
+         auto itr = _index.find(key);
+         if (itr == _index.end())
+            return;
+
+         _size -= itr->size();
+         _index.erase(itr);
+      }
+
+      uint64_t size() const {
+         return _size;
+      }
+
+      const ContainerType& index() const {
+         return _index;
+      }
+   };
+}

--- a/include/fc/container/tracked_storage.hpp
+++ b/include/fc/container/tracked_storage.hpp
@@ -59,11 +59,6 @@ namespace fc {
          }
       }
 
-      void insert(typename ContainerType::value_type&& obj) {
-         _size += obj.size();
-         _index.insert(std::move(obj));
-      }
-
       void insert(typename ContainerType::value_type obj) {
          _size += obj.size();
          _index.insert(std::move(obj));

--- a/include/fc/container/tracked_storage.hpp
+++ b/include/fc/container/tracked_storage.hpp
@@ -40,7 +40,7 @@ namespace fc {
             if (size() >= max_memory) {
                return false;
             }
-            ContainerType::value_type v;
+            typename ContainerType::value_type v;
             fc::raw::unpack(ds, v);
             insert(std::move(v));
          }
@@ -59,12 +59,12 @@ namespace fc {
          }
       }
 
-      void insert(ContainerType::value_type&& obj) {
+      void insert(typename ContainerType::value_type&& obj) {
          _size += obj.size();
          _index.insert(std::move(obj));
       }
 
-      void insert(ContainerType::value_type obj) {
+      void insert(typename ContainerType::value_type obj) {
          _size += obj.size();
          _index.insert(std::move(obj));
       }

--- a/include/fc/container/tracked_storage.hpp
+++ b/include/fc/container/tracked_storage.hpp
@@ -30,8 +30,8 @@ namespace fc {
 
       tracked_storage() = default;
 
-      // read in the contents of a persisted tracked_storage and limit the storage to
-      // max_memory.
+      // read in the contents of a persisted tracked_storage and prevent reading in
+      // more stored objects once max_memory is reached.
       // returns true if entire persisted tracked_storage was read
       bool read(fc::cfile_datastream& ds, size_t max_memory) {
          auto container_size = _index.size();

--- a/include/fc/container/tracked_storage.hpp
+++ b/include/fc/container/tracked_storage.hpp
@@ -1,12 +1,4 @@
 #pragma once
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/mem_fun.hpp>
-#include <boost/multi_index/global_fun.hpp>
-#include <boost/multi_index/composite_key.hpp>
-#include <boost/filesystem.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/io/cfile.hpp>
 #include <fc/io/datastream.hpp>
@@ -15,7 +7,6 @@
 #include <fstream>
 
 namespace eosio::chain_apis {
-   namespace bfs = boost::filesystem;
 
    /**
     * @class tracked_storage

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -142,41 +142,7 @@ public:
 
 
    static cfile read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
-      const uint32_t min_supported_version, const uint32_t max_supported_version) {
-      if (!fc::is_directory(dir))
-         fc::create_directories(dir);
-      
-      auto dat_file = dir / filename;
-      cfile dat_content;
-      dat_content.set_file_path(dat_file);
-      dat_content.open(cfile::update_rw_mode);
-      auto ds = dat_content.create_datastream();
-
-      // validate totem
-      uint32_t totem = 0;
-      fc::raw::unpack( ds, totem );
-      if( totem != magic_number) {
-         FC_THROW_EXCEPTION(fc::parse_error_exception,
-                            "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
-                            ("filename", dat_file.generic_string())
-                            ("actual_totem", totem)
-                            ("expected_totem", magic_number));
-      }
-
-      // validate version
-      uint32_t version = 0;
-      fc::raw::unpack( ds, version );
-      if( version < min_supported_version || version > max_supported_version) {
-         FC_THROW_EXCEPTION(fc::parse_error_exception,
-                            "Unsupported version of file '${filename}'. "
-                            "Version is ${version} while code supports version(s) [${min},${max}]",
-                            ("filename", dat_file.generic_string())
-                            ("version", version)
-                            ("min", min_supported_version)
-                            ("max", max_supported_version));
-      }
-      return dat_content;
-   }
+      const uint32_t min_supported_version, const uint32_t max_supported_version);
 
    static cfile write_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number, const uint32_t current_version) {
       if (!fc::is_directory(dir))
@@ -227,6 +193,43 @@ public:
 
 inline cfile_datastream cfile::create_datastream() {
    return cfile_datastream(*this);
+}
+
+cfile cfile::read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
+   const uint32_t min_supported_version, const uint32_t max_supported_version) {
+   if (!fc::is_directory(dir))
+      fc::create_directories(dir);
+   
+   auto dat_file = dir / filename;
+   cfile dat_content;
+   dat_content.set_file_path(dat_file);
+   dat_content.open(cfile::update_rw_mode);
+   auto ds = dat_content.create_datastream();
+
+   // validate totem
+   uint32_t totem = 0;
+   fc::raw::unpack( ds, totem );
+   if( totem != magic_number) {
+      FC_THROW_EXCEPTION(fc::parse_error_exception,
+                         "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
+                         ("filename", dat_file.generic_string())
+                         ("actual_totem", totem)
+                         ("expected_totem", magic_number));
+   }
+
+   // validate version
+   uint32_t version = 0;
+   fc::raw::unpack( ds, version );
+   if( version < min_supported_version || version > max_supported_version) {
+      FC_THROW_EXCEPTION(fc::parse_error_exception,
+                         "Unsupported version of file '${filename}'. "
+                         "Version is ${version} while code supports version(s) [${min},${max}]",
+                         ("filename", dat_file.generic_string())
+                         ("version", version)
+                         ("min", min_supported_version)
+                         ("max", max_supported_version));
+   }
+   return dat_content;
 }
 
 template <>

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -140,6 +140,56 @@ public:
 
    cfile_datastream create_datastream();
 
+
+   static cfile read_dat_file(const bfs::path& dir, const std::string& filename, const uint32_t magic_number,
+      const uint32_t min_supported_version, const uint32_t max_supported_version) {
+      if (!fc::is_directory(dir))
+         fc::create_directories(dir);
+      
+      auto dat_file = dir / filename;
+      cfile dat_content;
+      dat_content.set_file_path(dat_file);
+      dat_content.open(cfile::update_rw_mode);
+      auto ds = dat_content.create_datastream();
+
+      // validate totem
+      uint32_t totem = 0;
+      fc::raw::unpack( ds, totem );
+      if( totem != magic_number) {
+         FC_THROW_EXCEPTION(fc::parse_error_exception,
+                            "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
+                            ("filename", dat_file.generic_string())
+                            ("actual_totem", totem)
+                            ("expected_totem", magic_number));
+      }
+
+      // validate version
+      uint32_t version = 0;
+      fc::raw::unpack( ds, version );
+      if( version < min_supported_version || version > max_supported_version) {
+         FC_THROW_EXCEPTION(fc::parse_error_exception,
+                            "Unsupported version of file '${filename}'. "
+                            "Version is ${version} while code supports version(s) [${min},${max}]",
+                            ("filename", dat_file.generic_string())
+                            ("version", version)
+                            ("min", min_supported_version)
+                            ("max", max_supported_version));
+      }
+      return dat_content;
+   }
+
+   static cfile write_dat_file(const bfs::path& dir, const std::string& filename, const uint32_t magic_number, const uint32_t current_version) {
+      if (!fc::is_directory(dir))
+         fc::create_directories(dir);
+
+      auto dat_file = dir / filename;
+      cfile dat_content;
+      dat_content.set_file_path(dat_file.generic_string().c_str());
+      dat_content.open( cfile::truncate_rw_mode );
+      dat_content.write( reinterpret_cast<const char*>(&magic_number), sizeof(magic_number) );
+      dat_content.write( reinterpret_cast<const char*>(&current_version), sizeof(current_version) );
+      return dat_content;
+   }
 private:
    bool                  _open = false;
    fc::path              _file_path;

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -223,11 +223,10 @@ inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filena
    cfile_stream dat_content;
    dat_content.set_file_path(dat_file);
    dat_content.open(cfile::update_rw_mode);
-   auto ds = dat_content;
 
    // validate totem
    uint32_t totem = 0;
-   fc::raw::unpack( ds, totem );
+   fc::raw::unpack( dat_content, totem );
    if( totem != magic_number) {
       FC_THROW_EXCEPTION(fc::parse_error_exception,
                          "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
@@ -238,7 +237,7 @@ inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filena
 
    // validate version
    uint32_t version = 0;
-   fc::raw::unpack( ds, version );
+   fc::raw::unpack( dat_content, version );
    if( version < min_supported_version || version > max_supported_version) {
       FC_THROW_EXCEPTION(fc::parse_error_exception,
                          "Unsupported version of file '${filename}'. "

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -219,10 +219,11 @@ inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filena
       fc::create_directories(dir);
    
    auto dat_file = dir / filename;
-   cfile dat_content;
+   using cfile_stream = fc::datastream<fc::cfile>;
+   cfile_stream dat_content;
    dat_content.set_file_path(dat_file);
    dat_content.open(cfile::update_rw_mode);
-   auto ds = dat_content.create_datastream();
+   auto ds = dat_content;
 
    // validate totem
    uint32_t totem = 0;

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -195,7 +195,7 @@ inline cfile_datastream cfile::create_datastream() {
    return cfile_datastream(*this);
 }
 
-cfile cfile::read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
+inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
    const uint32_t min_supported_version, const uint32_t max_supported_version) {
    if (!fc::is_directory(dir))
       fc::create_directories(dir);

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -195,6 +195,24 @@ inline cfile_datastream cfile::create_datastream() {
    return cfile_datastream(*this);
 }
 
+template <>
+class datastream<fc::cfile, void> : public fc::cfile {
+ public:
+   using fc::cfile::cfile;
+
+   bool seekp(size_t pos) { return this->seek(pos), true; }
+
+   bool get(char& c) {
+      c = this->getc();
+      return true;
+   }
+
+   bool remaining() { return !this->eof(); }
+
+   fc::cfile&       storage() { return *this; }
+   const fc::cfile& storage() const { return *this; }
+};
+
 inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
    const uint32_t min_supported_version, const uint32_t max_supported_version) {
    if (!fc::is_directory(dir))
@@ -231,25 +249,6 @@ inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filena
    }
    return dat_content;
 }
-
-template <>
-class datastream<fc::cfile, void> : public fc::cfile {
- public:
-   using fc::cfile::cfile;
-
-   bool seekp(size_t pos) { return this->seek(pos), true; }
-
-   bool get(char& c) {
-      c = this->getc();
-      return true;
-   }
-
-   bool remaining() { return !this->eof(); }
-
-   fc::cfile&       storage() { return *this; }
-   const fc::cfile& storage() const { return *this; }
-};
-
 
 } // namespace fc
 

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -139,23 +139,6 @@ public:
    }
 
    cfile_datastream create_datastream();
-
-
-   static cfile read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
-      const uint32_t min_supported_version, const uint32_t max_supported_version);
-
-   static cfile write_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number, const uint32_t current_version) {
-      if (!fc::is_directory(dir))
-         fc::create_directories(dir);
-
-      auto dat_file = dir / filename;
-      cfile dat_content;
-      dat_content.set_file_path(dat_file.generic_string().c_str());
-      dat_content.open( cfile::truncate_rw_mode );
-      dat_content.write( reinterpret_cast<const char*>(&magic_number), sizeof(magic_number) );
-      dat_content.write( reinterpret_cast<const char*>(&current_version), sizeof(current_version) );
-      return dat_content;
-   }
 private:
    bool                  _open = false;
    fc::path              _file_path;
@@ -213,42 +196,6 @@ class datastream<fc::cfile, void> : public fc::cfile {
    const fc::cfile& storage() const { return *this; }
 };
 
-inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
-   const uint32_t min_supported_version, const uint32_t max_supported_version) {
-   if (!fc::is_directory(dir))
-      fc::create_directories(dir);
-   
-   auto dat_file = dir / filename;
-   using cfile_stream = fc::datastream<fc::cfile>;
-   cfile_stream dat_content;
-   dat_content.set_file_path(dat_file);
-   dat_content.open(cfile::update_rw_mode);
-
-   // validate totem
-   uint32_t totem = 0;
-   fc::raw::unpack( dat_content, totem );
-   if( totem != magic_number) {
-      FC_THROW_EXCEPTION(fc::parse_error_exception,
-                         "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
-                         ("filename", dat_file.generic_string())
-                         ("actual_totem", totem)
-                         ("expected_totem", magic_number));
-   }
-
-   // validate version
-   uint32_t version = 0;
-   fc::raw::unpack( dat_content, version );
-   if( version < min_supported_version || version > max_supported_version) {
-      FC_THROW_EXCEPTION(fc::parse_error_exception,
-                         "Unsupported version of file '${filename}'. "
-                         "Version is ${version} while code supports version(s) [${min},${max}]",
-                         ("filename", dat_file.generic_string())
-                         ("version", version)
-                         ("min", min_supported_version)
-                         ("max", max_supported_version));
-   }
-   return dat_content;
-}
 
 } // namespace fc
 

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -141,7 +141,7 @@ public:
    cfile_datastream create_datastream();
 
 
-   static cfile read_dat_file(const bfs::path& dir, const std::string& filename, const uint32_t magic_number,
+   static cfile read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
       const uint32_t min_supported_version, const uint32_t max_supported_version) {
       if (!fc::is_directory(dir))
          fc::create_directories(dir);
@@ -178,7 +178,7 @@ public:
       return dat_content;
    }
 
-   static cfile write_dat_file(const bfs::path& dir, const std::string& filename, const uint32_t magic_number, const uint32_t current_version) {
+   static cfile write_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number, const uint32_t current_version) {
       if (!fc::is_directory(dir))
          fc::create_directories(dir);
 

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -139,6 +139,7 @@ public:
    }
 
    cfile_datastream create_datastream();
+
 private:
    bool                  _open = false;
    fc::path              _file_path;

--- a/include/fc/io/persistence_util.hpp
+++ b/include/fc/io/persistence_util.hpp
@@ -25,8 +25,8 @@ namespace persistence_util {
       return dat_content;
    }
 
-   cfile read_persistence_header(cfile& dat_content, const uint32_t magic_number,
-      const uint32_t min_supported_version, const uint32_t max_supported_version, uint32_t& current_version) {
+   uint32_t read_persistence_header(cfile& dat_content, const uint32_t magic_number, const uint32_t min_supported_version,
+      const uint32_t max_supported_version) {
       auto ds = dat_content.create_datastream();
 
       // validate totem
@@ -34,8 +34,7 @@ namespace persistence_util {
       fc::raw::unpack( ds, totem );
       if( totem != magic_number) {
          FC_THROW_EXCEPTION(fc::parse_error_exception,
-                            "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
-                            ("filename", dat_file.generic_string())
+                            "File has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
                             ("actual_totem", totem)
                             ("expected_totem", magic_number));
       }
@@ -45,15 +44,14 @@ namespace persistence_util {
       fc::raw::unpack( ds, version );
       if( version < min_supported_version || version > max_supported_version) {
          FC_THROW_EXCEPTION(fc::parse_error_exception,
-                            "Unsupported version of file '${filename}'. "
+                            "Unsupported version for file. "
                             "Version is ${version} while code supports version(s) [${min},${max}]",
-                            ("filename", dat_file.generic_string())
                             ("version", version)
                             ("min", min_supported_version)
                             ("max", max_supported_version));
       }
 
-      return dat_content;
+      return version;
    }
 
    cfile open_cfile_for_write(const fc::path& dir, const std::string& filename) {

--- a/include/fc/io/persistence_util.hpp
+++ b/include/fc/io/persistence_util.hpp
@@ -56,52 +56,6 @@ namespace persistence_util {
       dat_content.write( reinterpret_cast<const char*>(&current_version), sizeof(current_version) );
       return dat_content;
    }
-}
-
-
-inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
-   const uint32_t min_supported_version, const uint32_t max_supported_version) {
-   if (!fc::is_directory(dir))
-      fc::create_directories(dir);
-   
-   auto dat_file = dir / filename;
-   using cfile_stream = fc::datastream<fc::cfile>;
-   cfile_stream dat_content;
-   dat_content.set_file_path(dat_file);
-   dat_content.open(cfile::update_rw_mode);
-
-   // validate totem
-   uint32_t totem = 0;
-   fc::raw::unpack( dat_content, totem );
-   if( totem != magic_number) {
-      FC_THROW_EXCEPTION(fc::parse_error_exception,
-                         "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
-                         ("filename", dat_file.generic_string())
-                         ("actual_totem", totem)
-                         ("expected_totem", magic_number));
-   }
-
-   // validate version
-   uint32_t version = 0;
-   fc::raw::unpack( dat_content, version );
-   if( version < min_supported_version || version > max_supported_version) {
-      FC_THROW_EXCEPTION(fc::parse_error_exception,
-                         "Unsupported version of file '${filename}'. "
-                         "Version is ${version} while code supports version(s) [${min},${max}]",
-                         ("filename", dat_file.generic_string())
-                         ("version", version)
-                         ("min", min_supported_version)
-                         ("max", max_supported_version));
-   }
-   return dat_content;
-}
+} // namespace persistence_util
 
 } // namespace fc
-
-#ifndef _WIN32
-#undef FC_FOPEN
-#else
-#undef FC_CAT
-#undef FC_PREL
-#undef FC_FOPEN
-#endif

--- a/include/fc/io/persistence_util.hpp
+++ b/include/fc/io/persistence_util.hpp
@@ -11,14 +11,16 @@ namespace persistence_util {
          fc::create_directories(dir);
       
       auto dat_file = dir / filename;
-      using cfile_stream = fc::datastream<fc::cfile>;
-      cfile_stream dat_content;
+
+      cfile dat_content;
       dat_content.set_file_path(dat_file);
       dat_content.open(cfile::update_rw_mode);
 
+      auto ds = dat_content.create_datastream();
+
       // validate totem
       uint32_t totem = 0;
-      fc::raw::unpack( dat_content, totem );
+      fc::raw::unpack( ds, totem );
       if( totem != magic_number) {
          FC_THROW_EXCEPTION(fc::parse_error_exception,
                             "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
@@ -29,7 +31,7 @@ namespace persistence_util {
 
       // validate version
       uint32_t version = 0;
-      fc::raw::unpack( dat_content, version );
+      fc::raw::unpack( ds, version );
       if( version < min_supported_version || version > max_supported_version) {
          FC_THROW_EXCEPTION(fc::parse_error_exception,
                             "Unsupported version of file '${filename}'. "

--- a/include/fc/io/persistence_util.hpp
+++ b/include/fc/io/persistence_util.hpp
@@ -67,7 +67,7 @@ namespace persistence_util {
       return dat_content;
    }
 
-   void write_persistence_file(cfile& dat_content, const uint32_t magic_number, const uint32_t current_version) {
+   void write_persistence_header(cfile& dat_content, const uint32_t magic_number, const uint32_t current_version) {
       dat_content.write( reinterpret_cast<const char*>(&magic_number), sizeof(magic_number) );
       dat_content.write( reinterpret_cast<const char*>(&current_version), sizeof(current_version) );
    }

--- a/include/fc/io/persistence_util.hpp
+++ b/include/fc/io/persistence_util.hpp
@@ -1,0 +1,105 @@
+#pragma once
+#include <fc/io/cfile.hpp>
+#include <fc/io/raw.hpp>
+
+namespace fc {
+
+namespace persistence_util {
+   cfile read_persistence_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
+      const uint32_t min_supported_version, const uint32_t max_supported_version) {
+      if (!fc::is_directory(dir))
+         fc::create_directories(dir);
+      
+      auto dat_file = dir / filename;
+      using cfile_stream = fc::datastream<fc::cfile>;
+      cfile_stream dat_content;
+      dat_content.set_file_path(dat_file);
+      dat_content.open(cfile::update_rw_mode);
+
+      // validate totem
+      uint32_t totem = 0;
+      fc::raw::unpack( dat_content, totem );
+      if( totem != magic_number) {
+         FC_THROW_EXCEPTION(fc::parse_error_exception,
+                            "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
+                            ("filename", dat_file.generic_string())
+                            ("actual_totem", totem)
+                            ("expected_totem", magic_number));
+      }
+
+      // validate version
+      uint32_t version = 0;
+      fc::raw::unpack( dat_content, version );
+      if( version < min_supported_version || version > max_supported_version) {
+         FC_THROW_EXCEPTION(fc::parse_error_exception,
+                            "Unsupported version of file '${filename}'. "
+                            "Version is ${version} while code supports version(s) [${min},${max}]",
+                            ("filename", dat_file.generic_string())
+                            ("version", version)
+                            ("min", min_supported_version)
+                            ("max", max_supported_version));
+      }
+      return dat_content;
+   }
+
+   cfile write_persistence_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number, const uint32_t current_version) {
+      if (!fc::is_directory(dir))
+         fc::create_directories(dir);
+
+      auto dat_file = dir / filename;
+      cfile dat_content;
+      dat_content.set_file_path(dat_file.generic_string().c_str());
+      dat_content.open( cfile::truncate_rw_mode );
+      dat_content.write( reinterpret_cast<const char*>(&magic_number), sizeof(magic_number) );
+      dat_content.write( reinterpret_cast<const char*>(&current_version), sizeof(current_version) );
+      return dat_content;
+   }
+}
+
+
+inline cfile cfile::read_dat_file(const fc::path& dir, const std::string& filename, const uint32_t magic_number,
+   const uint32_t min_supported_version, const uint32_t max_supported_version) {
+   if (!fc::is_directory(dir))
+      fc::create_directories(dir);
+   
+   auto dat_file = dir / filename;
+   using cfile_stream = fc::datastream<fc::cfile>;
+   cfile_stream dat_content;
+   dat_content.set_file_path(dat_file);
+   dat_content.open(cfile::update_rw_mode);
+
+   // validate totem
+   uint32_t totem = 0;
+   fc::raw::unpack( dat_content, totem );
+   if( totem != magic_number) {
+      FC_THROW_EXCEPTION(fc::parse_error_exception,
+                         "File '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
+                         ("filename", dat_file.generic_string())
+                         ("actual_totem", totem)
+                         ("expected_totem", magic_number));
+   }
+
+   // validate version
+   uint32_t version = 0;
+   fc::raw::unpack( dat_content, version );
+   if( version < min_supported_version || version > max_supported_version) {
+      FC_THROW_EXCEPTION(fc::parse_error_exception,
+                         "Unsupported version of file '${filename}'. "
+                         "Version is ${version} while code supports version(s) [${min},${max}]",
+                         ("filename", dat_file.generic_string())
+                         ("version", version)
+                         ("min", min_supported_version)
+                         ("max", max_supported_version));
+   }
+   return dat_content;
+}
+
+} // namespace fc
+
+#ifndef _WIN32
+#undef FC_FOPEN
+#else
+#undef FC_CAT
+#undef FC_PREL
+#undef FC_FOPEN
+#endif

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -4,7 +4,11 @@ target_link_libraries( test_cfile fc )
 add_executable( test_json test_json.cpp )
 target_link_libraries( test_json fc )
 
+add_executable( test_tracked_storage test_tracked_storage.cpp )
+target_link_libraries( test_tracked_storage fc )
+
 add_test(NAME test_cfile COMMAND libraries/fc/test/io/test_cfile WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME test_json COMMAND libraries/fc/test/io/test_json WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME test_tracked_storage COMMAND libraries/fc/test/io/test_tracked_storage WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
 
    fc::temp_directory td;
    auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
-   BOOST_CHECK(fc::persistence_util::write_persistence_header(out, 0x12345678, 5));
+   fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( version, 5 );
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
-   storage1_2.read(ds, 500);
+   BOOST_CHECK(storage1_2.read(ds, 500));
    BOOST_CHECK_EQUAL( storage1_2.index().size(), 0);
    BOOST_CHECK_EQUAL( storage1_2.size(), 0);
 
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 1);
    fc::temp_directory td;
    auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
-   BOOST_CHECK(fc::persistence_util::write_persistence_header(out, 0x12345678, 5));
+   fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
    BOOST_CHECK_EQUAL( version, 5 );
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
-   storage1_2.read(ds, 500);
+   BOOST_CHECK(storage1_2.read(ds, 500));
    BOOST_CHECK_EQUAL( storage1_2.index().size(), 1);
    const auto& primary_idx2 = storage1_2.index().get<by_key>();
    auto itr2 = primary_idx2.cbegin();
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
 
    fc::temp_directory td;
    auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
-   BOOST_CHECK(fc::persistence_util::write_persistence_header(out, 0x12345678, 5));
+   fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
    storage1_1.write(out);
 
    using tracked_storage2 = fc::tracked_storage<test_size2_container>;
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( version, 5 );
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
-   storage1_2.read(ds, 500);
+   BOOST_CHECK(storage1_2.read(ds, 500));
    BOOST_CHECK_EQUAL( storage1_2.index().size(), 8);
    const auto& primary_idx1_2 = storage1_2.index().get<by_key>();
    auto itr2 = primary_idx1_2.cbegin();
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_2.size(), 40);
 
    tracked_storage2 storage2_2;
-   storage2_2.read(ds, 500);
+   BOOST_CHECK(storage2_2.read(ds, 500));
    BOOST_CHECK_EQUAL( storage2_2.index().size(), 1);
    const auto& primary_idx2_2 = storage2_2.index().get<by_key>();
    auto itr3 = primary_idx2_2.cbegin();

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -57,11 +57,11 @@ BOOST_AUTO_TEST_SUITE(tracked_storage_tests)
 
 BOOST_AUTO_TEST_CASE(track_storage_test) {
    fc::tracked_storage<test_size_container> storage;
-   storage.insert({ 0, 5 });
+   storage.insert(test_size{ 0, 5 });
    BOOST_CHECK_EQUAL( storage.size(), 5);
-   storage.insert({ 1, 4 });
+   storage.insert(test_size{ 1, 4 });
    BOOST_CHECK_EQUAL( storage.size(), 9);
-   storage.insert({ 2, 15 });
+   storage.insert(test_size{ 2, 15 });
    BOOST_CHECK_EQUAL( storage.size(), 24);
    auto to_mod = storage.find(1);
    storage.modify(to_mod, [](test_size& ts) { ts.s = 14; });
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
 BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
    using tracked_storage1 = fc::tracked_storage<test_size_container>;
    tracked_storage1 storage1_1;
-   storage1_1.insert({ 0, 6 });
+   storage1_1.insert(test_size{ 0, 6 });
    BOOST_CHECK_EQUAL( storage1_1.size(), 6);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 1);
    fc::temp_directory td;
@@ -134,14 +134,14 @@ BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
 BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    using tracked_storage1 = fc::tracked_storage<test_size_container>;
    tracked_storage1 storage1_1;
-   storage1_1.insert({ 0, 6 });
-   storage1_1.insert({ 3, 7 });
-   storage1_1.insert({ 5, 3 });
-   storage1_1.insert({ 9, 4 });
-   storage1_1.insert({ 15, 6 });
-   storage1_1.insert({ 16, 4 });
-   storage1_1.insert({ 19, 3 });
-   storage1_1.insert({ 25, 7 });
+   storage1_1.insert(test_size{ 0, 6 });
+   storage1_1.insert(test_size{ 3, 7 });
+   storage1_1.insert(test_size{ 5, 3 });
+   storage1_1.insert(test_size{ 9, 4 });
+   storage1_1.insert(test_size{ 15, 6 });
+   storage1_1.insert(test_size{ 16, 4 });
+   storage1_1.insert(test_size{ 19, 3 });
+   storage1_1.insert(test_size{ 25, 7 });
    BOOST_CHECK_EQUAL( storage1_1.size(), 40);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 8);
 
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    using tracked_storage2 = fc::tracked_storage<test_size2_container>;
    tracked_storage2 storage2_1;
    const auto now = fc::time_point::now();
-   storage2_1.insert({ 3, now, 7 });
+   storage2_1.insert(test_size2{ 3, now, 7 });
    BOOST_CHECK_EQUAL( storage2_1.size(), 7);
    BOOST_CHECK_EQUAL( storage2_1.index().size(), 1);
 

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -79,14 +79,14 @@ BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_1.size(), 0);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 0);
 
-   // fc::temp_directory td;
-   auto out = fc::persistence_util::open_cfile_for_write(".", "temp.dat");
+   fc::temp_directory td;
+   auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
    fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
 
-   auto content = fc::persistence_util::open_cfile_for_read(".", "temp.dat");
+   auto content = fc::persistence_util::open_cfile_for_read(td.path(), "temp.dat");
    auto version = fc::persistence_util::read_persistence_header(content, 0x12345678, 5, 5);
    BOOST_CHECK_EQUAL( version, 5 );
    auto ds = content.create_datastream();
@@ -107,13 +107,13 @@ BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
    BOOST_CHECK_EQUAL( storage1_1.size(), 6);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 1);
    fc::temp_directory td;
-   auto out = fc::persistence_util::open_cfile_for_write(".", "temp.dat");
+   auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
    fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
 
-   auto content = fc::persistence_util::open_cfile_for_read(".", "temp.dat");
+   auto content = fc::persistence_util::open_cfile_for_read(td.path(), "temp.dat");
    auto version = fc::persistence_util::read_persistence_header(content, 0x12345678, 5, 5);
    BOOST_CHECK_EQUAL( version, 5 );
    auto ds = content.create_datastream();
@@ -145,7 +145,8 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_1.size(), 40);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 8);
 
-   auto out = fc::persistence_util::open_cfile_for_write(".", "temp.dat");
+   fc::temp_directory td;
+   auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
    fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
    storage1_1.write(out);
 
@@ -161,7 +162,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    out.flush();
    out.close();
 
-   auto content = fc::persistence_util::open_cfile_for_read(".", "temp.dat");
+   auto content = fc::persistence_util::open_cfile_for_read(td.path(), "temp.dat");
    auto version = fc::persistence_util::read_persistence_header(content, 0x12345678, 5, 5);
    BOOST_CHECK_EQUAL( version, 5 );
    auto ds = content.create_datastream();

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -1,6 +1,13 @@
 #define BOOST_TEST_MODULE tracked_storage
 #include <boost/test/included/unit_test.hpp>
 #include <fc/container/tracked_storage.hpp>
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/global_fun.hpp>
+#include <boost/multi_index/composite_key.hpp>
 #include <sstream>
 
 using boost::multi_index_container;
@@ -73,18 +80,13 @@ BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 0);
 
    // fc::temp_directory td;
-   BOOST_CHECK(true);
-   // auto ss = tracked_storage1::write_to_file(td.path(), "temp.dat", 0x12345678, 5);
-   auto out = tracked_storage1::write_to_file(".", "temp.dat", 0x12345678, 5);
+   auto out = tracked_storage1::write_dat_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
-   BOOST_CHECK(true);
 
-   auto content = tracked_storage1::read_from_file(".", "temp.dat", 0x12345678, 5, 5);
-   BOOST_CHECK(true);
+   auto content = tracked_storage1::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
-   BOOST_CHECK(true);
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);
    BOOST_CHECK_EQUAL( storage1_2.index().size(), 0);
@@ -102,12 +104,12 @@ BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
    BOOST_CHECK_EQUAL( storage1_1.size(), 6);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 1);
    fc::temp_directory td;
-   auto out = tracked_storage1::write_to_file(".", "temp.dat", 0x12345678, 5);
+   auto out = tracked_storage1::write_dat_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
 
-   auto content = tracked_storage1::read_from_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto content = tracked_storage1::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);
@@ -137,7 +139,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_1.size(), 40);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 8);
 
-   auto out = tracked_storage1::write_to_file(".", "temp.dat", 0x12345678, 5);
+   auto out = tracked_storage1::write_dat_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
 
    using tracked_storage2 = tracked_storage<test_size2_container, test_size2, by_key>;
@@ -152,7 +154,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    out.flush();
    out.close();
 
-   auto content = tracked_storage1::read_from_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto content = tracked_storage1::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -80,12 +80,12 @@ BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 0);
 
    // fc::temp_directory td;
-   auto out = tracked_storage1::write_dat_file(".", "temp.dat", 0x12345678, 5);
+   auto out = fc::cfile::write_dat_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
 
-   auto content = tracked_storage1::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto content = fc::cfile::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);
@@ -104,12 +104,12 @@ BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
    BOOST_CHECK_EQUAL( storage1_1.size(), 6);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 1);
    fc::temp_directory td;
-   auto out = tracked_storage1::write_dat_file(".", "temp.dat", 0x12345678, 5);
+   auto out = fc::cfile::write_dat_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
 
-   auto content = tracked_storage1::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto content = fc::cfile::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_1.size(), 40);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 8);
 
-   auto out = tracked_storage1::write_dat_file(".", "temp.dat", 0x12345678, 5);
+   auto out = fc::cfile::write_dat_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
 
    using tracked_storage2 = tracked_storage<test_size2_container, test_size2, by_key>;
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    out.flush();
    out.close();
 
-   auto content = tracked_storage1::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto content = fc::cfile::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -1,0 +1,194 @@
+#define BOOST_TEST_MODULE tracked_storage
+#include <boost/test/included/unit_test.hpp>
+#include <fc/container/tracked_storage.hpp>
+#include <sstream>
+
+using boost::multi_index_container;
+using namespace boost::multi_index;
+using namespace eosio::chain_apis;
+
+struct test_size {
+   uint64_t key;
+   uint64_t s;
+   uint64_t size() const {
+      return s;
+   }
+};
+
+FC_REFLECT( test_size, (key)(s) )
+
+struct by_key;
+typedef multi_index_container<
+   test_size,
+   indexed_by<
+      hashed_unique< tag<by_key>, member<test_size, uint64_t, &test_size::key>, std::hash<uint64_t>>
+   >
+> test_size_container;
+
+struct test_size2 {
+   uint64_t key;
+   fc::time_point time; 
+   uint64_t s;
+   uint64_t size() const {
+      return s;
+   }
+};
+
+FC_REFLECT( test_size2, (key)(time)(s) )
+
+struct by_time;
+typedef multi_index_container<
+   test_size2,
+   indexed_by<
+      hashed_unique< tag<by_key>, member<test_size2, uint64_t, &test_size2::key>, std::hash<uint64_t>>,
+      ordered_non_unique< tag<by_time>, member<test_size2, fc::time_point, &test_size2::time> >
+   >
+> test_size2_container;
+
+
+BOOST_AUTO_TEST_SUITE(tracked_storage_tests)
+
+BOOST_AUTO_TEST_CASE(track_storage_test) {
+   tracked_storage<test_size_container, test_size, by_key> storage;
+   storage.insert({ 0, 5 });
+   BOOST_CHECK_EQUAL( storage.size(), 5);
+   storage.insert({ 1, 4 });
+   BOOST_CHECK_EQUAL( storage.size(), 9);
+   storage.insert({ 2, 15 });
+   BOOST_CHECK_EQUAL( storage.size(), 24);
+   auto to_mod = storage.find(1);
+   storage.modify(to_mod, [](test_size& ts) { ts.s = 14; });
+   BOOST_CHECK_EQUAL( storage.size(), 34);
+   storage.modify(to_mod, [](test_size& ts) { ts.s = 0; });
+   BOOST_CHECK_EQUAL( storage.size(), 20);
+   storage.erase(2);
+   BOOST_CHECK_EQUAL( storage.size(), 5);
+   BOOST_CHECK_NO_THROW(storage.erase(2));
+}
+
+BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
+   using tracked_storage1 = tracked_storage<test_size_container, test_size, by_key>;
+   tracked_storage1 storage1_1;
+   BOOST_CHECK_EQUAL( storage1_1.size(), 0);
+   BOOST_CHECK_EQUAL( storage1_1.index().size(), 0);
+
+   // fc::temp_directory td;
+   BOOST_CHECK(true);
+   // auto ss = tracked_storage1::write_to_file(td.path(), "temp.dat", 0x12345678, 5);
+   auto out = tracked_storage1::write_to_file(".", "temp.dat", 0x12345678, 5);
+   storage1_1.write(out);
+   out.flush();
+   out.close();
+   BOOST_CHECK(true);
+
+   auto content = tracked_storage1::read_from_file(".", "temp.dat", 0x12345678, 5, 5);
+   BOOST_CHECK(true);
+   auto ds = content.create_datastream();
+   BOOST_CHECK(true);
+   tracked_storage1 storage1_2;
+   storage1_2.read(ds, 500);
+   BOOST_CHECK_EQUAL( storage1_2.index().size(), 0);
+   BOOST_CHECK_EQUAL( storage1_2.size(), 0);
+
+   const auto tellp = content.tellp();
+   content.seek_end(0);
+   BOOST_CHECK_EQUAL( content.tellp(), tellp );
+}
+
+BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
+   using tracked_storage1 = tracked_storage<test_size_container, test_size, by_key>;
+   tracked_storage1 storage1_1;
+   storage1_1.insert({ 0, 6 });
+   BOOST_CHECK_EQUAL( storage1_1.size(), 6);
+   BOOST_CHECK_EQUAL( storage1_1.index().size(), 1);
+   fc::temp_directory td;
+   auto out = tracked_storage1::write_to_file(".", "temp.dat", 0x12345678, 5);
+   storage1_1.write(out);
+   out.flush();
+   out.close();
+
+   auto content = tracked_storage1::read_from_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto ds = content.create_datastream();
+   tracked_storage1 storage1_2;
+   storage1_2.read(ds, 500);
+   BOOST_CHECK_EQUAL( storage1_2.index().size(), 1);
+   const auto& primary_idx2 = storage1_2.index().get<by_key>();
+   auto itr2 = primary_idx2.cbegin();
+   BOOST_CHECK_EQUAL( itr2->key, 0);
+   BOOST_CHECK_EQUAL( itr2->s, 6);
+   BOOST_CHECK_EQUAL( storage1_2.size(), 6);
+
+   const auto tellp = content.tellp();
+   content.seek_end(0);
+   BOOST_CHECK_EQUAL( content.tellp(), tellp );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
+   using tracked_storage1 = tracked_storage<test_size_container, test_size, by_key>;
+   tracked_storage1 storage1_1;
+   storage1_1.insert({ 0, 6 });
+   storage1_1.insert({ 3, 7 });
+   storage1_1.insert({ 5, 3 });
+   storage1_1.insert({ 9, 4 });
+   storage1_1.insert({ 15, 6 });
+   storage1_1.insert({ 16, 4 });
+   storage1_1.insert({ 19, 3 });
+   storage1_1.insert({ 25, 7 });
+   BOOST_CHECK_EQUAL( storage1_1.size(), 40);
+   BOOST_CHECK_EQUAL( storage1_1.index().size(), 8);
+
+   auto out = tracked_storage1::write_to_file(".", "temp.dat", 0x12345678, 5);
+   storage1_1.write(out);
+
+   using tracked_storage2 = tracked_storage<test_size2_container, test_size2, by_key>;
+   tracked_storage2 storage2_1;
+   const auto now = fc::time_point::now();
+   storage2_1.insert({ 3, now, 7 });
+   BOOST_CHECK_EQUAL( storage2_1.size(), 7);
+   BOOST_CHECK_EQUAL( storage2_1.index().size(), 1);
+
+   storage2_1.write(out);
+
+   out.flush();
+   out.close();
+
+   auto content = tracked_storage1::read_from_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto ds = content.create_datastream();
+   tracked_storage1 storage1_2;
+   storage1_2.read(ds, 500);
+   BOOST_CHECK_EQUAL( storage1_2.index().size(), 8);
+   const auto& primary_idx1_2 = storage1_2.index().get<by_key>();
+   auto itr2 = primary_idx1_2.cbegin();
+   BOOST_CHECK_EQUAL( itr2->key, 0);
+   BOOST_CHECK_EQUAL( itr2->s, 6);
+   BOOST_CHECK_EQUAL( (++itr2)->key, 3);
+   BOOST_CHECK_EQUAL( itr2->s, 7);
+   BOOST_CHECK_EQUAL( (++itr2)->key, 5);
+   BOOST_CHECK_EQUAL( itr2->s, 3);
+   BOOST_CHECK_EQUAL( (++itr2)->key, 9);
+   BOOST_CHECK_EQUAL( itr2->s, 4);
+   BOOST_CHECK_EQUAL( (++itr2)->key, 15);
+   BOOST_CHECK_EQUAL( itr2->s, 6);
+   BOOST_CHECK_EQUAL( (++itr2)->key, 16);
+   BOOST_CHECK_EQUAL( itr2->s, 4);
+   BOOST_CHECK_EQUAL( (++itr2)->key, 19);
+   BOOST_CHECK_EQUAL( itr2->s, 3);
+   BOOST_CHECK_EQUAL( (++itr2)->key, 25);
+   BOOST_CHECK_EQUAL( itr2->s, 7);
+   BOOST_CHECK_EQUAL( storage1_2.size(), 40);
+
+   tracked_storage2 storage2_2;
+   storage2_2.read(ds, 500);
+   BOOST_CHECK_EQUAL( storage2_2.index().size(), 1);
+   const auto& primary_idx2_2 = storage2_2.index().get<by_key>();
+   auto itr3 = primary_idx2_2.cbegin();
+   BOOST_CHECK_EQUAL( itr3->key, 3);
+   BOOST_CHECK( itr3->time == now);
+   BOOST_CHECK_EQUAL( itr3->s, 7);
+
+   const auto tellp = content.tellp();
+   content.seek_end(0);
+   BOOST_CHECK_EQUAL( content.tellp(), tellp );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -1,6 +1,7 @@
 #define BOOST_TEST_MODULE tracked_storage
 #include <boost/test/included/unit_test.hpp>
 #include <fc/container/tracked_storage.hpp>
+#include <fc/io/persistence_util.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -80,12 +81,12 @@ BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 0);
 
    // fc::temp_directory td;
-   auto out = fc::cfile::write_dat_file(".", "temp.dat", 0x12345678, 5);
+   auto out = fc::persistence_util::write_persistence_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
 
-   auto content = fc::cfile::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto content = fc::persistence_util::read_persistence_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);
@@ -104,12 +105,12 @@ BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
    BOOST_CHECK_EQUAL( storage1_1.size(), 6);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 1);
    fc::temp_directory td;
-   auto out = fc::cfile::write_dat_file(".", "temp.dat", 0x12345678, 5);
+   auto out = fc::persistence_util::write_persistence_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
    out.flush();
    out.close();
 
-   auto content = fc::cfile::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto content = fc::persistence_util::read_persistence_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);
@@ -139,7 +140,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    BOOST_CHECK_EQUAL( storage1_1.size(), 40);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 8);
 
-   auto out = fc::cfile::write_dat_file(".", "temp.dat", 0x12345678, 5);
+   auto out = fc::persistence_util::write_persistence_file(".", "temp.dat", 0x12345678, 5);
    storage1_1.write(out);
 
    using tracked_storage2 = tracked_storage<test_size2_container, test_size2, by_key>;
@@ -154,7 +155,7 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
    out.flush();
    out.close();
 
-   auto content = fc::cfile::read_dat_file(".", "temp.dat", 0x12345678, 5, 5);
+   auto content = fc::persistence_util::read_persistence_file(".", "temp.dat", 0x12345678, 5, 5);
    auto ds = content.create_datastream();
    tracked_storage1 storage1_2;
    storage1_2.read(ds, 500);

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -56,7 +56,7 @@ typedef multi_index_container<
 BOOST_AUTO_TEST_SUITE(tracked_storage_tests)
 
 BOOST_AUTO_TEST_CASE(track_storage_test) {
-   fc::tracked_storage<test_size_container, test_size, by_key> storage;
+   fc::tracked_storage<test_size_container> storage;
    storage.insert({ 0, 5 });
    BOOST_CHECK_EQUAL( storage.size(), 5);
    storage.insert({ 1, 4 });
@@ -74,14 +74,14 @@ BOOST_AUTO_TEST_CASE(track_storage_test) {
 }
 
 BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
-   using tracked_storage1 = fc::tracked_storage<test_size_container, test_size, by_key>;
+   using tracked_storage1 = fc::tracked_storage<test_size_container>;
    tracked_storage1 storage1_1;
    BOOST_CHECK_EQUAL( storage1_1.size(), 0);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 0);
 
    fc::temp_directory td;
    auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
-   fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
+   BOOST_CHECK(fc::persistence_util::write_persistence_header(out, 0x12345678, 5));
    storage1_1.write(out);
    out.flush();
    out.close();
@@ -101,14 +101,14 @@ BOOST_AUTO_TEST_CASE(simple_write_read_file_storage_test) {
 }
 
 BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
-   using tracked_storage1 = fc::tracked_storage<test_size_container, test_size, by_key>;
+   using tracked_storage1 = fc::tracked_storage<test_size_container>;
    tracked_storage1 storage1_1;
    storage1_1.insert({ 0, 6 });
    BOOST_CHECK_EQUAL( storage1_1.size(), 6);
    BOOST_CHECK_EQUAL( storage1_1.index().size(), 1);
    fc::temp_directory td;
    auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
-   fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
+   BOOST_CHECK(fc::persistence_util::write_persistence_header(out, 0x12345678, 5));
    storage1_1.write(out);
    out.flush();
    out.close();
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(single_write_read_file_storage_test) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
-   using tracked_storage1 = fc::tracked_storage<test_size_container, test_size, by_key>;
+   using tracked_storage1 = fc::tracked_storage<test_size_container>;
    tracked_storage1 storage1_1;
    storage1_1.insert({ 0, 6 });
    storage1_1.insert({ 3, 7 });
@@ -147,10 +147,10 @@ BOOST_AUTO_TEST_CASE(write_read_file_storage_test) {
 
    fc::temp_directory td;
    auto out = fc::persistence_util::open_cfile_for_write(td.path(), "temp.dat");
-   fc::persistence_util::write_persistence_header(out, 0x12345678, 5);
+   BOOST_CHECK(fc::persistence_util::write_persistence_header(out, 0x12345678, 5));
    storage1_1.write(out);
 
-   using tracked_storage2 = fc::tracked_storage<test_size2_container, test_size2, by_key>;
+   using tracked_storage2 = fc::tracked_storage<test_size2_container>;
    tracked_storage2 storage2_1;
    const auto now = fc::time_point::now();
    storage2_1.insert({ 3, now, 7 });


### PR DESCRIPTION
Added tracked_storage class to keep track of memory allocated to a boost multi-index.

Also added methods for reading/writing the header for a persistence file.