### PR TITLE
cfile updates and fix for mac

### DIFF
--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -66,30 +66,41 @@ public:
 
    void seek( long loc ) {
       if( 0 != fseek( _file.get(), loc, SEEK_SET ) ) {
+         int err = ferror(_file.get());
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
-                                       " unable to SEEK_SET to: " + std::to_string(loc) );
+                                       " unable to SEEK_SET to: " + std::to_string(loc) +
+                                       ", ec: " + std::to_string(err) );
       }
    }
 
    void seek_end( long loc ) {
       if( 0 != fseek( _file.get(), loc, SEEK_END ) ) {
+         int err = ferror(_file.get());
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
-                                       " unable to SEEK_END to: " + std::to_string(loc) );
+                                       " unable to SEEK_END to: " + std::to_string(loc) +
+                                       ", ec: " + std::to_string(err) );
       }
    }
 
    void skip( long loc) {
       if( 0 != fseek( _file.get(), loc, SEEK_CUR ) ) {
+         int err = ferror(_file.get());
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
-                                       " unable to SEEK_CUR to: " + std::to_string(loc) );
+                                       " unable to SEEK_CUR to: " + std::to_string(loc) +
+                                       ", ec: " + std::to_string(err) );
       }
    }
 
    void read( char* d, size_t n ) {
       size_t result = fread( d, 1, n, _file.get() );
       if( result != n ) {
+         int err = ferror(_file.get());
+         int eof = feof(_file.get());
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
-                                       " unable to read " + std::to_string( n ) + " bytes; only read " + std::to_string( result ) );
+                                       " unable to read " + std::to_string( n ) + " bytes;"
+                                       " only read " + std::to_string( result ) +
+                                       ", eof: " + (eof == 0 ? "false" : "true") +
+                                       ", ec: " + std::to_string(err) );
       }
    }
 
@@ -190,8 +201,6 @@ class datastream<fc::cfile, void> : public fc::cfile {
       c = this->getc();
       return true;
    }
-
-   bool remaining() { return !this->eof(); }
 
    fc::cfile&       storage() { return *this; }
    const fc::cfile& storage() const { return *this; }

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -69,7 +69,7 @@ public:
          int err = ferror(_file.get());
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
                                        " unable to SEEK_SET to: " + std::to_string(loc) +
-                                       ", ec: " + std::to_string(err) );
+                                       ", ferror: " + std::to_string(err) );
       }
    }
 
@@ -78,7 +78,7 @@ public:
          int err = ferror(_file.get());
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
                                        " unable to SEEK_END to: " + std::to_string(loc) +
-                                       ", ec: " + std::to_string(err) );
+                                       ", ferror: " + std::to_string(err) );
       }
    }
 
@@ -87,7 +87,7 @@ public:
          int err = ferror(_file.get());
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
                                        " unable to SEEK_CUR to: " + std::to_string(loc) +
-                                       ", ec: " + std::to_string(err) );
+                                       ", ferror: " + std::to_string(err) );
       }
    }
 
@@ -100,7 +100,7 @@ public:
                                        " unable to read " + std::to_string( n ) + " bytes;"
                                        " only read " + std::to_string( result ) +
                                        ", eof: " + (eof == 0 ? "false" : "true") +
-                                       ", ec: " + std::to_string(err) );
+                                       ", ferror: " + std::to_string(err) );
       }
    }
 
@@ -114,9 +114,9 @@ public:
 
    void flush() {
       if( 0 != fflush( _file.get() ) ) {
-         int ec = ferror( _file.get() );
+         int err = ferror( _file.get() );
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
-                                       " unable to flush file, ferror: " + std::to_string( ec ) );
+                                       " unable to flush file, ferror: " + std::to_string( err ) );
       }
    }
 

--- a/include/fc/io/persistence_util.hpp
+++ b/include/fc/io/persistence_util.hpp
@@ -27,6 +27,7 @@ namespace persistence_util {
 
    uint32_t read_persistence_header(cfile& dat_content, const uint32_t magic_number, const uint32_t min_supported_version,
       const uint32_t max_supported_version) {
+      dat_content.seek(0); // needed on mac
       auto ds = dat_content.create_datastream();
 
       // validate totem


### PR DESCRIPTION
- Add ferror and feof info to cfile exception info
- Removed `remaining()` see https://github.com/EOSIO/fc/pull/187
- Add call to `seek(0)` to `read_persistence_header` needed on mac as it does not open file at beginning
