### PR TITLE
Allow memory size of tracked_storage to be specialized

### DIFF
--- a/include/fc/container/tracked_storage.hpp
+++ b/include/fc/container/tracked_storage.hpp
@@ -9,12 +9,12 @@
 namespace fc {
 
    /**
-    * Specialize tracked::size() if obj does not provide a size() method that represents memory size.
+    * Specialize tracked::memory_size() if obj does not provide a memory_size() method that represents memory size.
     */
    namespace tracked {
       template<typename T>
-      size_t size( const T& obj ) {
-         return obj.size();
+      size_t memory_size( const T& obj ) {
+         return obj.memory_size();
       }
    }
 
@@ -70,7 +70,7 @@ namespace fc {
       }
 
       std::pair<typename primary_index_type::iterator, bool> insert(typename ContainerType::value_type obj) {
-         const auto size = tracked::size(obj);
+         const auto size = tracked::memory_size(obj);
          auto result = _index.insert(std::move(obj));
          if (result.second) {
             _memory_size += size;
@@ -92,9 +92,9 @@ namespace fc {
 
       template<typename Lam>
       void modify(typename primary_index_type::iterator itr, Lam lam) {
-         _memory_size -= tracked::size(*itr);
+         _memory_size -= tracked::memory_size(*itr);
          if (_index.modify( itr, std::move(lam))) {
-            _memory_size += tracked::size(*itr);
+            _memory_size += tracked::memory_size(*itr);
          }
       }
 
@@ -104,7 +104,7 @@ namespace fc {
          if (itr == _index.end())
             return;
 
-         _memory_size -= tracked::size(*itr);
+         _memory_size -= tracked::memory_size(*itr);
          _index.erase(itr);
       }
 

--- a/include/fc/container/tracked_storage.hpp
+++ b/include/fc/container/tracked_storage.hpp
@@ -9,6 +9,16 @@
 namespace fc {
 
    /**
+    * Specialize tracked::size() if obj does not provide a size() method that represents memory size.
+    */
+   namespace tracked {
+      template<typename T>
+      size_t size( const T& obj ) {
+         return obj.size();
+      }
+   }
+
+   /**
     * @class tracked_storage
     * @brief tracks the size of storage allocated to its underlying multi_index
     *
@@ -17,7 +27,8 @@ namespace fc {
     * methods for persistence.
     * 
     * Requires ContainerType::value_type to have a size() method that represents the
-    * memory used for that object and is required to be a pack/unpack-able type.
+    * memory used for that object or specialized tracked::size() and is required to
+    * be a pack/unpack-able type.
     */
 
    template <typename ContainerType>
@@ -59,7 +70,7 @@ namespace fc {
       }
 
       std::pair<typename primary_index_type::iterator, bool> insert(typename ContainerType::value_type obj) {
-         const auto size = obj.size();
+         const auto size = tracked::size(obj);
          auto result = _index.insert(std::move(obj));
          if (result.second) {
             _memory_size += size;
@@ -81,9 +92,9 @@ namespace fc {
 
       template<typename Lam>
       void modify(typename primary_index_type::iterator itr, Lam lam) {
-         _memory_size -= itr->size();
+         _memory_size -= tracked::size(*itr);
          if (_index.modify( itr, std::move(lam))) {
-            _memory_size += itr->size();
+            _memory_size += tracked::size(*itr);
          }
       }
 
@@ -93,7 +104,7 @@ namespace fc {
          if (itr == _index.end())
             return;
 
-         _memory_size -= itr->size();
+         _memory_size -= tracked::size(*itr);
          _index.erase(itr);
       }
 

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -36,12 +36,16 @@ struct test_size2 {
    uint64_t key = 0;
    fc::time_point time; 
    uint64_t s = 0;
-   uint64_t size() const {
-      return s;
-   }
 };
 
 FC_REFLECT( test_size2, (key)(time)(s) )
+
+namespace fc::tracked {
+  template<>
+  size_t size(const test_size2& t) {
+     return t.s;
+  }
+}
 
 struct by_time;
 typedef multi_index_container<

--- a/test/io/test_tracked_storage.cpp
+++ b/test/io/test_tracked_storage.cpp
@@ -17,9 +17,6 @@ using namespace boost::multi_index;
 struct test_size {
    uint64_t key = 0;
    uint64_t s = 0;
-   uint64_t size() const {
-      return s;
-   }
 };
 
 FC_REFLECT( test_size, (key)(s) )
@@ -42,7 +39,12 @@ FC_REFLECT( test_size2, (key)(time)(s) )
 
 namespace fc::tracked {
   template<>
-  size_t size(const test_size2& t) {
+  size_t memory_size(const test_size& t) {
+     return t.s;
+  }
+
+  template<>
+  size_t memory_size(const test_size2& t) {
      return t.s;
   }
 }


### PR DESCRIPTION
Provide memory size for tracked_storage by specializing `memory_size` templated function.