### PR TITLE
Huangminghuang/fix boost 1.78

### DIFF
--- a/include/fc/crypto/sha256.hpp
+++ b/include/fc/crypto/sha256.hpp
@@ -3,6 +3,7 @@
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
 #include <fc/io/raw_fwd.hpp>
+#include <boost/functional/hash.hpp>
 
 namespace fc
 {

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -14,6 +14,7 @@
 #include <array>
 #include <map>
 #include <deque>
+#include <list>
 
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/interprocess/containers/string.hpp>


### PR DESCRIPTION
This PR fixes the missing include when compiling with boost 1.78.0