### PR TITLE
Porting EPE-1661-mock-time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set( fc_sources
      src/variant_object.cpp
      src/string.cpp
      src/time.cpp
+     src/mock_time.cpp
      src/utf8.cpp
      src/io/datastream.cpp
      src/io/json.cpp

--- a/include/fc/mock_time.hpp
+++ b/include/fc/mock_time.hpp
@@ -15,7 +15,7 @@ public:
    typedef source_traits::duration_type duration_type;
 
    // Requires set_now() to be called first on main thread before any calls to fc::time_point::now()
-   static time_type now() { return now_.load(); }
+   static time_type now() noexcept { return now_.load(); }
 
    // First call should be on one thread before any calls to fc::time_point::now()
    static void set_now( time_type t );

--- a/include/fc/mock_time.hpp
+++ b/include/fc/mock_time.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <fc/time.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <optional>
+
+
+namespace fc {
+
+/// mock out fc::time_point::now() and provide a mock deadline timer
+class mock_time_traits {
+   typedef boost::asio::deadline_timer::traits_type source_traits;
+public:
+   typedef source_traits::time_type time_type;
+   typedef source_traits::duration_type duration_type;
+
+   // Requires set_now() to be called before now(), only valid if is_set() is true
+   static time_type now() { return *now_; }
+
+   static void set_now( time_type t );
+
+   static bool is_set() { return now_.has_value(); }
+
+   static time_type add( time_type t, duration_type d ) { return source_traits::add( t, d ); }
+   static duration_type subtract( time_type t1, time_type t2 ) { return source_traits::subtract( t1, t2 ); }
+   static bool less_than( time_type t1, time_type t2 ) { return source_traits::less_than( t1, t2 ); }
+
+   // This function is called by asio to determine how often to check
+   // if the timer is ready to fire. By manipulating this function, we
+   // can make sure asio detects changes to now_ in a timely fashion.
+   static boost::posix_time::time_duration to_posix_duration( duration_type d ) {
+      return d < boost::posix_time::milliseconds( 1 ) ? d : boost::posix_time::milliseconds( 1 );
+   }
+
+   // return now as fc::time_point, used by fc::time_point::now() if mock_time_traits is_set()
+   static fc::time_point fc_now();
+
+private:
+   static std::optional<time_type> now_;
+};
+
+typedef boost::asio::basic_deadline_timer<boost::posix_time::ptime, mock_time_traits> mock_deadline_timer;
+
+} // namespace fc

--- a/include/fc/mock_time.hpp
+++ b/include/fc/mock_time.hpp
@@ -2,8 +2,6 @@
 
 #include <fc/time.hpp>
 #include <boost/asio/deadline_timer.hpp>
-#include <optional>
-
 
 namespace fc {
 
@@ -15,7 +13,7 @@ public:
    typedef source_traits::duration_type duration_type;
 
    // Requires set_now() to be called first on main thread before any calls to fc::time_point::now()
-   static time_type now() noexcept { return now_.load(); }
+   static time_type now() noexcept;
 
    // First call should be on one thread before any calls to fc::time_point::now()
    static void set_now( time_type t );
@@ -39,7 +37,8 @@ public:
 
 private:
    static bool mock_enabled_;
-   static std::atomic<time_type> now_;
+   static const boost::posix_time::ptime epoch_;
+   static std::atomic<int64_t> now_;
 };
 
 typedef boost::asio::basic_deadline_timer<boost::posix_time::ptime, mock_time_traits> mock_deadline_timer;

--- a/src/mock_time.cpp
+++ b/src/mock_time.cpp
@@ -3,10 +3,12 @@
 
 namespace fc {
 
-std::optional<mock_time_traits::time_type> mock_time_traits::now_{};
+std::atomic<mock_time_traits::time_type> mock_time_traits::now_{};
+bool mock_time_traits::mock_enabled_ = false;
 
 void mock_time_traits::set_now( time_type t ) {
    now_ = t;
+   if( !mock_enabled_ ) mock_enabled_ = true;
 
    // After modifying the clock, we need to sleep the thread to give the io_service
    // the opportunity to poll and notice the change in clock time.

--- a/src/mock_time.cpp
+++ b/src/mock_time.cpp
@@ -16,7 +16,7 @@ void mock_time_traits::set_now( time_type t ) {
 
 fc::time_point mock_time_traits::fc_now() {
    static const boost::posix_time::ptime epoch( boost::gregorian::date( 1970, 1, 1 ) );
-   return fc::time_point( fc::microseconds( ( epoch - mock_time_traits::now() ).total_microseconds() ) );
+   return fc::time_point( fc::microseconds( ( mock_time_traits::now() - epoch ).total_microseconds() ) );
 }
 
 } //namespace fc

--- a/src/mock_time.cpp
+++ b/src/mock_time.cpp
@@ -1,0 +1,22 @@
+#include <fc/mock_time.hpp>
+#include <thread>
+
+namespace fc {
+
+std::optional<mock_time_traits::time_type> mock_time_traits::now_{};
+
+void mock_time_traits::set_now( time_type t ) {
+   now_ = t;
+
+   // After modifying the clock, we need to sleep the thread to give the io_service
+   // the opportunity to poll and notice the change in clock time.
+   // See to_posix_duration()
+   std::this_thread::sleep_for( std::chrono::milliseconds( 2 ) );
+}
+
+fc::time_point mock_time_traits::fc_now() {
+   static const boost::posix_time::ptime epoch( boost::gregorian::date( 1970, 1, 1 ) );
+   return fc::time_point( fc::microseconds( ( epoch - mock_time_traits::now() ).total_microseconds() ) );
+}
+
+} //namespace fc

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -1,4 +1,5 @@
 #include <fc/time.hpp>
+#include <fc/mock_time.hpp>
 #include <fc/variant.hpp>
 #include <boost/chrono/system_clocks.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -12,6 +13,9 @@ namespace fc {
 
   time_point time_point::now()
   {
+     if( UNLIKELY(mock_time_traits::is_set()) ) {
+        return mock_time_traits::fc_now();
+     }
      return time_point( microseconds( bch::duration_cast<bch::microseconds>( bch::system_clock::now().time_since_epoch() ).count() ) );
   }
 


### PR DESCRIPTION
Provides ability to control fc::time_point::now() via mock_time_traits