### PR TITLE
Provide set_now that takes a fc::time_point

### DIFF
--- a/include/fc/mock_time.hpp
+++ b/include/fc/mock_time.hpp
@@ -17,6 +17,7 @@ public:
 
    // First call should be on one thread before any calls to fc::time_point::now()
    static void set_now( time_type t );
+   static void set_now( const fc::time_point& now );
 
    // Thread safe only if first call to set_now is before any threads are spawned or memory barrier introduced
    static bool is_set() { return mock_enabled_; }

--- a/src/mock_time.cpp
+++ b/src/mock_time.cpp
@@ -12,7 +12,12 @@ mock_time_traits::time_type mock_time_traits::now() noexcept {
 }
 
 void mock_time_traits::set_now( time_type t ) {
-   now_ = (t - epoch_).total_microseconds();
+   fc::time_point now( fc::microseconds( (t - epoch_).total_microseconds() ) );
+   set_now( now );
+}
+
+void mock_time_traits::set_now( const fc::time_point& now ) {
+   now_ = now.time_since_epoch().count();
    if( !mock_enabled_ ) mock_enabled_ = true;
 
    // After modifying the clock, we need to sleep the thread to give the io_service


### PR DESCRIPTION
- Only makes sense to have a `fc::time_point` version of `set_now` so you don't have to use `boost::posix::time`