### PR TITLE
variant::estimated_size()

### DIFF
--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -310,7 +310,7 @@ namespace fc
         /// @pre is_array()
         size_t                      size()const;
 
-        size_t                        estimated_size();
+        size_t                      estimated_size()const;
         /**
          *  _types that use non-intrusive variant conversion can implement the
          *  following method to implement conversion from variant to T.

--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -310,6 +310,7 @@ namespace fc
         /// @pre is_array()
         size_t                      size()const;
 
+        size_t                        estimated_size();
         /**
          *  _types that use non-intrusive variant conversion can implement the
          *  following method to implement conversion from variant to T.

--- a/include/fc/variant_object.hpp
+++ b/include/fc/variant_object.hpp
@@ -91,7 +91,7 @@ namespace fc
       variant_object& operator=( mutable_variant_object&& );
       variant_object& operator=( const mutable_variant_object& );
 
-      size_t estimated_size();
+      size_t estimated_size()const;
 
    private:
       std::shared_ptr< std::vector< entry > > _key_value;

--- a/include/fc/variant_object.hpp
+++ b/include/fc/variant_object.hpp
@@ -91,6 +91,8 @@ namespace fc
       variant_object& operator=( mutable_variant_object&& );
       variant_object& operator=( const mutable_variant_object& );
 
+      size_t estimated_size();
+
    private:
       std::shared_ptr< std::vector< entry > > _key_value;
       friend class mutable_variant_object;

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -586,7 +586,7 @@ size_t variant::estimated_size()const
       return as_string().length() + sizeof(string) + sizeof(*this);
    case array_type:
    {
-      auto arr = get_array();
+      const auto& arr = get_array();
       auto arr_size = arr.size();
       size_t sum = sizeof(*this) + sizeof(variants);
       for (size_t iter = 0; iter < arr_size; ++iter) {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -572,36 +572,32 @@ size_t            variant::size()const
     return get_array().size();
 }
 
-size_t variant::estimated_size()
+size_t variant::estimated_size()const
 {
-   size_t iter = 0;
-   size_t sum = 0;
    switch( get_type() )
    {
    case null_type:
-      return 0;
    case int64_type:
-      return sizeof(int64_t);
    case uint64_type:
-      return sizeof(uint64_t);
    case double_type:
-      return sizeof(double);
    case bool_type:
-      return sizeof(bool);
+      return sizeof(*this);
    case string_type:
-      return as_string().length();
+      return as_string().length() + sizeof(string) + sizeof(*this);
    case array_type:
-      sum += sizeof(size_t);
-      for (iter; iter < size(); ++iter) {
-         sum += get_array()[iter].estimated_size();
+   {
+      auto arr = get_array();
+      auto arr_size = arr.size();
+      size_t sum = sizeof(*this) + sizeof(variants);
+      for (size_t iter = 0; iter < arr_size; ++iter) {
+         sum += arr[iter].estimated_size();
       }
       return sum;
+   }
    case object_type:
-      return get_object().estimated_size();
+      return get_object().estimated_size() + sizeof(*this);
    case blob_type:
-      sum += sizeof(size_t);
-      sum += get_blob().data.size();
-      return sum;
+      return sizeof(blob) + get_blob().data.size() + sizeof(*this);
    default:
       FC_THROW_EXCEPTION( assert_exception, "Invalid Type / Corrupted Memory" );
    }

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -572,6 +572,41 @@ size_t            variant::size()const
     return get_array().size();
 }
 
+size_t variant::estimated_size()
+{
+   size_t iter = 0;
+   size_t sum = 0;
+   switch( get_type() )
+   {
+   case null_type:
+      return 0;
+   case int64_type:
+      return sizeof(int64_t);
+   case uint64_type:
+      return sizeof(uint64_t);
+   case double_type:
+      return sizeof(double);
+   case bool_type:
+      return sizeof(bool);
+   case string_type:
+      return as_string().length();
+   case array_type:
+      sum += sizeof(size_t);
+      for (iter; iter < size(); ++iter) {
+         sum += get_array()[iter].estimated_size();
+      }
+      return sum;
+   case object_type:
+      return get_object().estimated_size();
+   case blob_type:
+      sum += sizeof(size_t);
+      sum += get_blob().data.size();
+      return sum;
+   default:
+      FC_THROW_EXCEPTION( assert_exception, "Invalid Type / Corrupted Memory" );
+   }
+}
+
 const string&        variant::get_string()const
 {
   if( get_type() == string_type )

--- a/src/variant_object.cpp
+++ b/src/variant_object.cpp
@@ -167,8 +167,9 @@ namespace fc
       auto kv_size = size();
       size_t sum = sizeof(*this) + sizeof(std::vector<entry>);
       for (size_t iter = 0; iter < kv_size; ++iter) {
-         sum += _key_value->at(iter).key().length() + sizeof(string);
-         sum += _key_value->at(iter).value().estimated_size();
+         const auto& kv = _key_value->at(iter);
+         sum += kv.key().length() + sizeof(string);
+         sum += kv.value().estimated_size();
       }
       return sum;
    }

--- a/src/variant_object.cpp
+++ b/src/variant_object.cpp
@@ -162,11 +162,12 @@ namespace fc
       return *this;
    }
 
-   size_t variant_object::estimated_size()
+   size_t variant_object::estimated_size()const
    {
-      size_t sum = 0;
-      for (size_t iter = 0; iter < size(); ++iter) {
-         sum += _key_value->at(iter).key().length();
+      auto kv_size = size();
+      size_t sum = sizeof(*this) + sizeof(std::vector<entry>);
+      for (size_t iter = 0; iter < kv_size; ++iter) {
+         sum += _key_value->at(iter).key().length() + sizeof(string);
          sum += _key_value->at(iter).value().estimated_size();
       }
       return sum;

--- a/src/variant_object.cpp
+++ b/src/variant_object.cpp
@@ -162,6 +162,15 @@ namespace fc
       return *this;
    }
 
+   size_t variant_object::estimated_size()
+   {
+      size_t sum = 0;
+      for (size_t iter = 0; iter < size(); ++iter) {
+         sum += _key_value->at(iter).key().length();
+         sum += _key_value->at(iter).value().estimated_size();
+      }
+      return sum;
+   }
 
    void to_variant( const variant_object& var,  variant& vo )
    {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory( network )
 add_subdirectory( scoped_exit )
 add_subdirectory( static_variant )
 add_subdirectory( variant )
+add_subdirectory( variant_estimated_size )
 
 add_executable( test_base64 test_base64.cpp )
 target_link_libraries( test_base64 fc )

--- a/test/variant_estimated_size/CMakeLists.txt
+++ b/test/variant_estimated_size/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable( variant_estimated_size test_variant_estimated_size.cpp )
+target_link_libraries( variant_estimated_size fc )
+
+add_test(NAME test_variant COMMAND libraries/fc/test/variant_estimated_size/test_variant_estimated_size WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/variant_estimated_size/test_variant_estimated_size.cpp
+++ b/test/variant_estimated_size/test_variant_estimated_size.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(variant_object_variant_estimated_size_test)
    string k1 = "key_bool";
    string k2 = "key_string";
    string k3 = "key_int16";
-   string k4 = "key_blob"; // 35 + 4 * sizeof(string) 
+   string k4 = "key_blob"; // 35 + 4 * sizeof(string)
 
    bool b = false;
    string s = "HelloWorld"; // 10 + sizeof(string)

--- a/test/variant_estimated_size/test_variant_estimated_size.cpp
+++ b/test/variant_estimated_size/test_variant_estimated_size.cpp
@@ -16,8 +16,8 @@ BOOST_AUTO_TEST_CASE(null_variant_estimated_size_test)
    variant v;
    variant v_nullptr(np);
 
-   BOOST_CHECK_EQUAL(v.estimated_size(), 0);
-   BOOST_CHECK_EQUAL(v_nullptr.estimated_size(), 0);
+   BOOST_CHECK_EQUAL(v.estimated_size(), sizeof(variant));
+   BOOST_CHECK_EQUAL(v_nullptr.estimated_size(), sizeof(variant));
 }
 
 BOOST_AUTO_TEST_CASE(int64_variant_estimated_size_test)
@@ -32,10 +32,10 @@ BOOST_AUTO_TEST_CASE(int64_variant_estimated_size_test)
    variant v_int_16(k);
    variant v_int_8(l);
 
-   BOOST_CHECK_EQUAL(v_int_64.estimated_size(), 8);
-   BOOST_CHECK_EQUAL(v_int_32.estimated_size(), 8);
-   BOOST_CHECK_EQUAL(v_int_16.estimated_size(), 8);
-   BOOST_CHECK_EQUAL(v_int_8.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_int_64.estimated_size(), sizeof(variant));
+   BOOST_CHECK_EQUAL(v_int_32.estimated_size(), sizeof(variant));
+   BOOST_CHECK_EQUAL(v_int_16.estimated_size(), sizeof(variant));
+   BOOST_CHECK_EQUAL(v_int_8.estimated_size(), sizeof(variant));
 }
 
 BOOST_AUTO_TEST_CASE(uint64_variant_estimated_size_test)
@@ -50,10 +50,10 @@ BOOST_AUTO_TEST_CASE(uint64_variant_estimated_size_test)
    variant v_uint_16(k);
    variant v_uint_8(l);
 
-   BOOST_CHECK_EQUAL(v_uint_64.estimated_size(), 8);
-   BOOST_CHECK_EQUAL(v_uint_32.estimated_size(), 8);
-   BOOST_CHECK_EQUAL(v_uint_16.estimated_size(), 8);
-   BOOST_CHECK_EQUAL(v_uint_8.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_uint_64.estimated_size(), sizeof(variant));
+   BOOST_CHECK_EQUAL(v_uint_32.estimated_size(), sizeof(variant));
+   BOOST_CHECK_EQUAL(v_uint_16.estimated_size(), sizeof(variant));
+   BOOST_CHECK_EQUAL(v_uint_8.estimated_size(), sizeof(variant));
 }
 
 BOOST_AUTO_TEST_CASE(double_variant_estimated_size_test)
@@ -64,8 +64,8 @@ BOOST_AUTO_TEST_CASE(double_variant_estimated_size_test)
    variant v_float(f);
    variant v_double(d);
 
-   BOOST_CHECK_EQUAL(v_float.estimated_size(), 8);
-   BOOST_CHECK_EQUAL(v_double.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_float.estimated_size(), sizeof(variant));
+   BOOST_CHECK_EQUAL(v_double.estimated_size(), sizeof(variant));
 }
 
 BOOST_AUTO_TEST_CASE(string_variant_estimated_size_test)
@@ -82,11 +82,11 @@ BOOST_AUTO_TEST_CASE(string_variant_estimated_size_test)
    variant v_const_wchar(cwc);
    variant v_string(s);
 
-   BOOST_CHECK_EQUAL(v_char.estimated_size(), 11);
-   BOOST_CHECK_EQUAL(v_const_char.estimated_size(), 7);
-   BOOST_CHECK_EQUAL(v_wchar.estimated_size(), 10);
-   BOOST_CHECK_EQUAL(v_const_wchar.estimated_size(), 3);
-   BOOST_CHECK_EQUAL(v_string.estimated_size(), 26);
+   BOOST_CHECK_EQUAL(v_char.estimated_size(), 11 + sizeof(variant) + sizeof(string));
+   BOOST_CHECK_EQUAL(v_const_char.estimated_size(), 7 + sizeof(variant) + sizeof(string));
+   BOOST_CHECK_EQUAL(v_wchar.estimated_size(), 10 + sizeof(variant) + sizeof(string));
+   BOOST_CHECK_EQUAL(v_const_wchar.estimated_size(), 3 + sizeof(variant) + sizeof(string));
+   BOOST_CHECK_EQUAL(v_string.estimated_size(), 26 + sizeof(variant) + sizeof(string));
 }
 
 BOOST_AUTO_TEST_CASE(blob_variant_estimated_size_test)
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(blob_variant_estimated_size_test)
 
    variant v_blob(bl);
 
-   BOOST_CHECK_EQUAL(v_blob.estimated_size(), 3 + sizeof(size_t));
+   BOOST_CHECK_EQUAL(v_blob.estimated_size(), 3 + sizeof(variant) + sizeof(blob));
 }
 
 BOOST_AUTO_TEST_CASE(variant_object_variant_estimated_size_test)
@@ -106,49 +106,52 @@ BOOST_AUTO_TEST_CASE(variant_object_variant_estimated_size_test)
    string k1 = "key_bool";
    string k2 = "key_string";
    string k3 = "key_int16";
-   string k4 = "key_blob";
+   string k4 = "key_blob"; // 35 + 4 * sizeof(string) 
 
    bool b = false;
-   string s = "HelloWorld";
+   string s = "HelloWorld"; // 10 + sizeof(string)
    int16_t i = 123;
    blob bl;
    bl.data.push_back('b');
    bl.data.push_back('a');
-   bl.data.push_back('r');
+   bl.data.push_back('r'); // 3 + sizeof(blob)
 
    variant v_bool(b);
    variant v_string(s);
    variant v_int16(i);
-   variant v_blob(bl);
+   variant v_blob(bl); // + 4 * sizeof(variant)
 
    mutable_variant_object mu;
-   mu(k1, b);          // 0  (sum) + 8  (key) + 1    (bool)   = 9
-   mu(k2, v_string);   // 9  (sum) + 10 (key) + 10   (string) = 29
-   mu(k3, v_int16);    // 29 (sum) + 9  (key) + 8    (int64)  = 46
-   mu(k4, bl);         // 46 (sum) + 8  (key) + 7/11 (blob)   = 61/65
+   mu(k1, b);
+   mu(k2, v_string);
+   mu(k3, v_int16);
+   mu(k4, bl);
+   variant_object vo(mu); // + sizeof(variant_object) + sizeof(std::vector<variant_object::entry>)
+   variant v_vo(vo); // + sizeof(variant)
 
-   variant_object vo(mu);
-
-   BOOST_CHECK_EQUAL(vo.estimated_size(), 57 + sizeof(size_t));
+   BOOST_CHECK_EQUAL(vo.estimated_size(), 48 + 5 * sizeof(string) + sizeof(blob) + 4 * sizeof(variant) +
+                     sizeof(variant_object) + sizeof(std::vector<variant_object::entry>));
+   BOOST_CHECK_EQUAL(v_vo.estimated_size(), 48 + 5 * sizeof(string) + sizeof(blob) + 5 * sizeof(variant) +
+                     sizeof(variant_object) + sizeof(std::vector<variant_object::entry>));
 }
 
 BOOST_AUTO_TEST_CASE(array_variant_estimated_size_test)
 {
    bool b = true;
-   wchar_t wc[] = L"Goodbye";
+   wchar_t wc[] = L"Goodbye"; // 7 + sizeof(string)
    uint32_t i = 54321;
 
    variant v_bool(b);
    variant v_wchar(wc);
-   variant v_uint32(i);
+   variant v_uint32(i); // + 3 * sizeof(variant)
 
-   variants vs;
+   variants vs; // + sizeof(variants)
    vs.push_back(v_bool);
    vs.push_back(v_wchar);
    vs.push_back(v_uint32);
 
-   variant v_variants(vs);
-   BOOST_CHECK_EQUAL(v_variants.estimated_size(), 16 + sizeof(size_t));
+   variant v_variants(vs); // + sizeof(variant)
+   BOOST_CHECK_EQUAL(v_variants.estimated_size(), 7 + sizeof(string) + 4 * sizeof(variant) + sizeof(variants));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/variant_estimated_size/test_variant_estimated_size.cpp
+++ b/test/variant_estimated_size/test_variant_estimated_size.cpp
@@ -1,0 +1,154 @@
+#define BOOST_TEST_MODULE variant
+#include <boost/test/included/unit_test.hpp>
+
+#include <fc/variant_object.hpp>
+#include <fc/exception/exception.hpp>
+#include <fc/crypto/base64.hpp>
+#include <string>
+
+using namespace fc;
+
+BOOST_AUTO_TEST_SUITE(variant_estimated_size_suite)
+BOOST_AUTO_TEST_CASE(null_variant_estimated_size_test)
+{
+   nullptr_t np;
+
+   variant v;
+   variant v_nullptr(np);
+
+   BOOST_CHECK_EQUAL(v.estimated_size(), 0);
+   BOOST_CHECK_EQUAL(v_nullptr.estimated_size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(int64_variant_estimated_size_test)
+{
+   int64_t i = 1;
+   int32_t j = 2;
+   int16_t k = 3;
+   int8_t l = 4;
+
+   variant v_int_64(i);
+   variant v_int_32(j);
+   variant v_int_16(k);
+   variant v_int_8(l);
+
+   BOOST_CHECK_EQUAL(v_int_64.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_int_32.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_int_16.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_int_8.estimated_size(), 8);
+}
+
+BOOST_AUTO_TEST_CASE(uint64_variant_estimated_size_test)
+{
+   uint64_t i = 1;
+   uint32_t j = 2;
+   uint16_t k = 3;
+   uint8_t l = 4;
+
+   variant v_uint_64(i);
+   variant v_uint_32(j);
+   variant v_uint_16(k);
+   variant v_uint_8(l);
+
+   BOOST_CHECK_EQUAL(v_uint_64.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_uint_32.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_uint_16.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_uint_8.estimated_size(), 8);
+}
+
+BOOST_AUTO_TEST_CASE(double_variant_estimated_size_test)
+{
+   float f = 3.14;
+   double d = 12.345;
+
+   variant v_float(f);
+   variant v_double(d);
+
+   BOOST_CHECK_EQUAL(v_float.estimated_size(), 8);
+   BOOST_CHECK_EQUAL(v_double.estimated_size(), 8);
+}
+
+BOOST_AUTO_TEST_CASE(string_variant_estimated_size_test)
+{
+   char c[] = "Hello World";
+   const char* cc = "Goodbye";
+   wchar_t wc[] = L"0123456789";
+   const wchar_t* cwc = L"foo";
+   string s = "abcdefghijklmnopqrstuvwxyz";
+
+   variant v_char(c);
+   variant v_const_char(cc);
+   variant v_wchar(wc);
+   variant v_const_wchar(cwc);
+   variant v_string(s);
+
+   BOOST_CHECK_EQUAL(v_char.estimated_size(), 11);
+   BOOST_CHECK_EQUAL(v_const_char.estimated_size(), 7);
+   BOOST_CHECK_EQUAL(v_wchar.estimated_size(), 10);
+   BOOST_CHECK_EQUAL(v_const_wchar.estimated_size(), 3);
+   BOOST_CHECK_EQUAL(v_string.estimated_size(), 26);
+}
+
+BOOST_AUTO_TEST_CASE(blob_variant_estimated_size_test)
+{
+   blob bl;
+   bl.data.push_back('f');
+   bl.data.push_back('o');
+   bl.data.push_back('o');
+
+   variant v_blob(bl);
+
+   BOOST_CHECK_EQUAL(v_blob.estimated_size(), 3 + sizeof(size_t));
+}
+
+BOOST_AUTO_TEST_CASE(variant_object_variant_estimated_size_test)
+{
+   string k1 = "key_bool";
+   string k2 = "key_string";
+   string k3 = "key_int16";
+   string k4 = "key_blob";
+
+   bool b = false;
+   string s = "HelloWorld";
+   int16_t i = 123;
+   blob bl;
+   bl.data.push_back('b');
+   bl.data.push_back('a');
+   bl.data.push_back('r');
+
+   variant v_bool(b);
+   variant v_string(s);
+   variant v_int16(i);
+   variant v_blob(bl);
+
+   mutable_variant_object mu;
+   mu(k1, b);          // 0  (sum) + 8  (key) + 1    (bool)   = 9
+   mu(k2, v_string);   // 9  (sum) + 10 (key) + 10   (string) = 29
+   mu(k3, v_int16);    // 29 (sum) + 9  (key) + 8    (int64)  = 46
+   mu(k4, bl);         // 46 (sum) + 8  (key) + 7/11 (blob)   = 61/65
+
+   variant_object vo(mu);
+
+   BOOST_CHECK_EQUAL(vo.estimated_size(), 57 + sizeof(size_t));
+}
+
+BOOST_AUTO_TEST_CASE(array_variant_estimated_size_test)
+{
+   bool b = true;
+   wchar_t wc[] = L"Goodbye";
+   uint32_t i = 54321;
+
+   variant v_bool(b);
+   variant v_wchar(wc);
+   variant v_uint32(i);
+
+   variants vs;
+   vs.push_back(v_bool);
+   vs.push_back(v_wchar);
+   vs.push_back(v_uint32);
+
+   variant v_variants(vs);
+   BOOST_CHECK_EQUAL(v_variants.estimated_size(), 16 + sizeof(size_t));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Adds estimated_size() function to get an estimated size in bytes of a variant.

This a recursive function that will sum the size of everything within the variant in order to get an estimate of the size of the variant in memory.