### PR TITLE
Extend GELF appender to support user-defined fields.

### DIFF
--- a/include/fc/log/gelf_appender.hpp
+++ b/include/fc/log/gelf_appender.hpp
@@ -4,6 +4,8 @@
 #include <fc/log/logger.hpp>
 #include <fc/time.hpp>
 
+#include <regex>
+
 namespace fc 
 {
   // Log appender that sends log messages in JSON format over UDP
@@ -13,8 +15,11 @@ namespace fc
   public:
     struct config 
     {
+      static const std::vector<std::string> reserved_field_names;
+      static const std::regex user_field_name_pattern;
       string endpoint = "127.0.0.1:12201";
       string host = "fc"; // the name of the host, source or application that sent this message (just passed through to GELF server)
+      variant_object user_fields = {};
     };
 
     gelf_appender(const variant& args);
@@ -37,4 +42,4 @@ namespace fc
 
 #include <fc/reflect/reflect.hpp>
 FC_REFLECT(fc::gelf_appender::config,
-           (endpoint)(host))
+           (endpoint)(host)(user_fields))


### PR DESCRIPTION
Resolves eosnetworkfoundation/mandel#91.

The GELF appender now supports arbitrary fields and accompanying values in the logging.json configuration file, with some restrictions.  Per the GELF specification, user-defined field names must begin with an underscore and contain only letters, numbers, underscores, dashes, and dots.  The regular expression against which field names are checked is: `^_[\w\.\-]*$`.  Beyond the format check, there is also a list of reserved field names which are reserved by the specification or used by nodeos.  The list of reserved field names is:

- _id
- _timestamp_ns
- _log_id
- _line
- _file
- _method_name
- _thread_name
- _task_name

There is no enforced limit on the length of the field name nor the accompanying value.  However, by default, Graylog servers are configured to drop UDP GELF log messages which exceed 128 fragments.  The GELF appender limits its payload size to 512 bytes, so field names and values with a combined length of somewhat less than 65536 bytes may result in lost log messages.  The GELF protocol allows a maximum of 256 fragments, so a combined length exceeding 131072 bytes will always result in lost log messages.  There is also no enforced limit regarding the number of user-defined fields beyond those limits described above.

The Graylog server automatically elides the leading underscore in user-defined fields when displaying them in selectors and in the interface.