### PR TITLE
on macos, do a full sync in cfile's sync()

### DIFF
--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -4,6 +4,10 @@
 #include <cstdio>
 #include <ios>
 
+#ifdef __APPLE__
+#include <fcntl.h>
+#endif
+
 #ifndef _WIN32
 #define FC_FOPEN(p, m) fopen(p, m)
 #else
@@ -136,6 +140,12 @@ public:
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
                                        " unable to sync file, error: " + std::to_string( errno ) );
       }
+#ifdef __APPLE__
+      if( -1 == fcntl( fd, F_FULLFSYNC ) ) {
+         throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
+                                       " unable to F_FULLFSYNC file, error: " + std::to_string( errno ) );
+      }
+#endif
    }
 
    bool eof() const { return feof(_file.get()) != 0; }


### PR DESCRIPTION
The semantics of `fsync()` are very different between Linux & macOS. macOS does not guarantee that the data is on disk when `fsync()` returns. For that, you need to `F_FULLFSYNC` too.

I believe the intention of `cfile::sync()` is that the data is indeed on the disk once it returns, so make this behave similarly on both platforms. I also suspect the reason EOSIO/eos#10690 was never really encountered by the dev team before was because on macOS this `fsync()` call is cheap & fast unlike on Linux.