### PR TITLE
Logstash fails to decompress best compression but succeeds with default.

### DIFF
--- a/src/compress/zlib.cpp
+++ b/src/compress/zlib.cpp
@@ -12,7 +12,7 @@ namespace fc
   {
     string out;
     bio::filtering_ostream comp;
-    comp.push(bio::zlib_compressor(bio::zlib::best_compression));
+    comp.push(bio::zlib_compressor(bio::zlib::default_compression));
     comp.push(bio::back_inserter(out));
     bio::write(comp, in.data(), in.size());
     bio::close(comp);


### PR DESCRIPTION
Graylog accepts either, so use least common denominator.