### PR TITLE
add cfile::get_mapping_handle() for boost interprocess

### DIFF
--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -6,6 +6,8 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include <boost/interprocess/file_mapping.hpp>
+
 #ifndef _WIN32
 #define FC_FOPEN(p, m) fopen(p, m)
 #else
@@ -200,6 +202,10 @@ public:
    void close() {
       _file.reset();
       _open = false;
+   }
+
+   boost::interprocess::mapping_handle_t get_mapping_handle() const {
+      return {fileno(), false};
    }
 
    cfile_datastream create_datastream();


### PR DESCRIPTION
This adds to `cfile` a `get_mapping_handle()` which implements the `MemoryMappable` in boost interprocess. It allows one to create a `boost::interprocess::mapped_region` directly from the cfile without opening a new handle and such.
```c++
boost::interprocess::mapped_region mapped_thing(some_cfile, boost::interprocess::read_write);
```
Now... the problem is... I'm not really sure `mapping_handle_t` is really considered a public type; or really if even the `MemoryMappable` interface is either. But without leveraging this, one must reopen a new handle to a file to use it with a `mapped_region` which is undesirable. 