### PR TITLE
add cfile::get_mapping_handle() for boost interprocess

### DIFF
--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -6,6 +6,8 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include <boost/interprocess/file_mapping.hpp>
+
 #ifndef _WIN32
 #define FC_FOPEN(p, m) fopen(p, m)
 #else
@@ -200,6 +202,10 @@ public:
    void close() {
       _file.reset();
       _open = false;
+   }
+
+   boost::interprocess::mapping_handle_t get_mapping_handle() const {
+      return {fileno(), false};
    }
 
    cfile_datastream create_datastream();


### PR DESCRIPTION
deja vu? yep! it's #31 back from the dead since I couldn't revive it there.

While admittedly it's gnarly to bring in a boost interprocess header dependency to this file, making cfile implement the `MemoryMappable` interface sure does make code cleaner that wants to pass `cfile` off to a `boost::interprocess::mapped_region` -- no worries about lifetime of a separate adapter or such.