### PR TITLE
fix compile errors in cfile hole punching on macos - 3.1

### DIFF
--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -170,8 +170,8 @@ public:
 #if defined(__linux__)
       ret = fallocate(fileno(), FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE, begin, end-begin);
 #elif defined(__APPLE__)
-      struct fpunchhole puncher = {0, 0, begin, end-begin};
-      ret = fcntl(block_file.fileno(), F_PUNCHHOLE, &puncher);
+      struct fpunchhole puncher = {0, 0, static_cast<off_t>(begin), static_cast<off_t>(end-begin)};
+      ret = fcntl(fileno(), F_PUNCHHOLE, &puncher);
 #endif
       if(ret == -1)
          wlog("Failed to punch hole in file ${f}: ${e}", ("f", _file_path)("e", strerror(errno)));


### PR DESCRIPTION
`fallocate()` parameters are also `off_t` so maybe we should convert to `off_t` earlier in the function, but it's nice keeping them unsigned imo. Just do a late conversion to `off_t` for macos otherwise errors out with
```
error: non-constant-expression cannot be narrowed from type 'unsigned long long' to 'off_t' (aka 'long long') in initializer list [-Wc++11-narrowing]
```

This is a clear defect that is clutched in when using fc on macos so I'll go ahead and add it to 3.1 even though mandel as a whole has other difficulties with 3.1 on macos.