### PR TITLE
[3.1 -> main] alt_bn128: allow decoding of element zero for g1 and g2

### DIFF
--- a/include/fc/crypto/alt_bn128.hpp
+++ b/include/fc/crypto/alt_bn128.hpp
@@ -11,7 +11,6 @@ namespace fc {
 
     enum class alt_bn128_error : int32_t {
         operand_component_invalid,
-        operand_at_origin,
         operand_not_in_curve,
         pairing_list_size_error,
         operand_outside_g2,

--- a/src/crypto/alt_bn128.cpp
+++ b/src/crypto/alt_bn128.cpp
@@ -55,7 +55,7 @@ namespace fc {
         }
 
         if (x.is_zero() && y.is_zero()) {
-            return alt_bn128_error::operand_at_origin;
+            return libff::alt_bn128_G1::zero();
         }
 
         libff::alt_bn128_G1 point{x, y, libff::alt_bn128_Fq::one()};
@@ -85,6 +85,9 @@ namespace fc {
     }
 
     std::variant<alt_bn128_error, libff::alt_bn128_G2> decode_g2_element(const bytes& bytes128_be) noexcept {
+        if(bytes128_be.size() != 128) {
+            return alt_bn128_error::input_len_error;
+        }
 
         bytes sub1(bytes128_be.begin(), bytes128_be.begin()+64);        
         auto maybe_x = decode_fp2_element(sub1);
@@ -102,7 +105,7 @@ namespace fc {
         const auto& y = std::get<libff::alt_bn128_Fq2>(maybe_y);
 
         if (x.is_zero() && y.is_zero()) {
-            return alt_bn128_error::operand_at_origin;
+            return libff::alt_bn128_G2::zero();
         }
 
         libff::alt_bn128_G2 point{x, y, libff::alt_bn128_Fq2::one()};

--- a/test/crypto/test_alt_bn128.cpp
+++ b/test/crypto/test_alt_bn128.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(add) try {
         {
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "1bd20beca3d8d28e536d2b5bd3bf36d76af68af5e6c96ca6e5519ba9ff8f53322a53edf6b48bcf5cb1c0b4ad1d36dfce06a79dcd6526f1c386a14d8ce4649844",
-            alt_bn128_error::operand_at_origin
+            to_bytes("1bd20beca3d8d28e536d2b5bd3bf36d76af68af5e6c96ca6e5519ba9ff8f53322a53edf6b48bcf5cb1c0b4ad1d36dfce06a79dcd6526f1c386a14d8ce4649844")
         },
     };
 
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(mul) try {
         {
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "0312ed43559cf8ecbab5221256a56e567aac5035308e3f1d54954d8b97cd1c9b",
-            alt_bn128_error::operand_at_origin,
+            to_bytes("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
         },
 
     };
@@ -203,22 +203,6 @@ BOOST_AUTO_TEST_CASE(pair) try {
 
             },
             alt_bn128_error::pairing_list_size_error
-        },
-
-        //test4: 1 pair => (G1_a,G2_a) ; alt_bn128_error::operand_at_origin; false
-        {
-            {
-                { //G1_a G2_a
-                    "0000000000000000000000000000000000000000000000000000000000000000", //G1_a.x
-                    "0000000000000000000000000000000000000000000000000000000000000000", //G1_a.y
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2", //G2_b.x
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b", //G2_b.y
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa"
-                },
-
-            },
-            alt_bn128_error::operand_at_origin
         },
 
         //test5: 1 pair => (G1_a,G2_a) ; alt_bn128_error::operand_not_in_curve; false


### PR DESCRIPTION
Bringing https://github.com/eosnetworkfoundation/mandel-fc/pull/40 into `main`.