### PR TITLE
[3.1 -> main] check for errors in fc::read_file_contents()

### DIFF
--- a/src/io/fstream.cpp
+++ b/src/io/fstream.cpp
@@ -15,9 +15,11 @@ namespace fc {
    {
       const boost::filesystem::path& bfp = filename;
       boost::filesystem::ifstream f( bfp, std::ios::in | std::ios::binary );
+      FC_ASSERT(f, "Failed to open ${filename}", ("filename", filename));
       // don't use fc::stringstream here as we need something with override for << rdbuf()
       std::stringstream ss;
       ss << f.rdbuf();
+      FC_ASSERT(f, "Failed reading ${filename}", ("filename", filename));
       result = ss.str();
    }
   


### PR DESCRIPTION
Needed for: [3.1->main] of https://github.com/eosnetworkfoundation/mandel/pull/646