### PR TITLE
[3.2] FC submodule -- Add FIFO (named pipe) support for deep-mind logging

### DIFF
--- a/include/fc/log/dmlog_appender.hpp
+++ b/include/fc/log/dmlog_appender.hpp
@@ -15,6 +15,7 @@ namespace fc {
             struct config
             {
                std::string file = "-";
+               std::string fifo = "-";
             };
             explicit dmlog_appender( const variant& args );
             explicit dmlog_appender( const std::optional<config>& args) ;
@@ -31,4 +32,4 @@ namespace fc {
    };
 }
 
-FC_REFLECT(fc::dmlog_appender::config, (file))
+FC_REFLECT(fc::dmlog_appender::config, (file)(fifo))


### PR DESCRIPTION
Resolve https://github.com/eosnetworkfoundation/mandel/issues/221.

Add FIFO support for deep-mind logging to FIFO in FC submodule. The changes in `nodeos` is done in a separate PR https://github.com/eosnetworkfoundation/mandel/pull/723